### PR TITLE
Fixed wrong method name in commands.mjs

### DIFF
--- a/setup/commands.mjs
+++ b/setup/commands.mjs
@@ -30,7 +30,7 @@ export default async function setupCommands(client) {
     // Handle commands and interaction interceptors command name/key/button ids.
     client.on('interactionCreate', async interaction => {
         const command = client.commands.get(interaction.commandName);
-        if (!command) return InteractionHelper._onInteraction(interaction);
+        if (!command) return InteractionHelper._onInteract(interaction);
 
         try {
             await command.execute(interaction);


### PR DESCRIPTION
- InteractionHelper class method _onInteract was referenced with incorrect name in commands.mjs