### PR TITLE
MOTW Compensation for high base points

### DIFF
--- a/operations/minigames/medium/economy/points/pointsHelper.mjs
+++ b/operations/minigames/medium/economy/points/pointsHelper.mjs
@@ -86,10 +86,18 @@ export default class PointsHelper {
         const qty = Math.max(1, await Items.getUserItemQty(userID, 'COOP_POINT'));
         const diff = qty - oldPoints;
         let percChange = (diff / oldPoints) * 100;
+
+        // Logarithmic gain that scales up based on user total points
+        const logGain = Math.floor(Math.max(1, Math.min(Math.log10(qty), 100)));
+
+        // Increment change by the amount of extra points gained from difference
+        // based on the total amount of points user has,
+        percChange + Math.floor(diff * (logGain / 10));
         
         // Prevent the weird unnecessary result that occurs without it.
         // Defies mathematical/js sense...? Maybe string/int type collision.
         if (isNaN(percChange)) percChange = 0;
+
 
         return {
             userID: userID,


### PR DESCRIPTION
- Added log10 based extra points to the member of the week calculation
- This compensates users that have alot of points
- log10 Starting curve after user base points are around 100