### PR TITLE
Fixed wrong method name in manifest

### DIFF
--- a/operations/manifest.mjs
+++ b/operations/manifest.mjs
@@ -109,7 +109,7 @@ export default function eventsManifest() {
   EventsHelper.runInterval(() => ActivityHelper.track(), baseTickDur / 1.75);
 
   // Track the competitions, start/end if necessary.
-  EventsHelper.runInterval(() => CompetitionHelper.track(), baseTickDur * 8);
+  EventsHelper.runInterval(() => CompetitionHelper.sync(), baseTickDur * 8);
 
   // Track spotlight event until required.
   EventsHelper.runInterval(() => SpotlightHelper.track(), baseTickDur * 20);


### PR DESCRIPTION
- Competition helper function was previously called "track" but changed to "sync" to describe behaviour.
- Changed the method name to "sync" in manifest