### PR TITLE
Fix spotlight helper not ending

### DIFF
--- a/operations/members/spotlightHelper.mjs
+++ b/operations/members/spotlightHelper.mjs
@@ -38,7 +38,7 @@ export default class SpotlightHelper {
                 await this.run();
 
             // End the event if necessary.
-            else if (isActive && hasExpired)
+            else if (hasExpired)
                 await this.end();
 
             else {


### PR DESCRIPTION
- Fixes spotlight deadlock where non active spotlight is always triggering the last else condition