### PR TITLE
Droptable and Chestpop fixes

### DIFF
--- a/operations/minigames/medium/economy/items/droptable.mjs
+++ b/operations/minigames/medium/economy/items/droptable.mjs
@@ -105,7 +105,10 @@ export default class DropTable {
     }
 
     static getRandomTiered(level) {
-        return STATE.CHANCE.pickone(this.TIERS[level]);
+        return STATE.CHANCE.weighted(
+            [this.TIERS.LEGENDARY, this.TIERS.RARE, this.TIERS.AVERAGE],
+            [this.TIER_QTYS.LEGENDARY.max, this.TIER_QTYS.RARE.max, this.TIER_QTYS.AVERAGE.max]
+        );
     }
 
     // This is effectively complete, but need to figure out when it will be used.

--- a/operations/minigames/small/chestpop.mjs
+++ b/operations/minigames/small/chestpop.mjs
@@ -32,7 +32,7 @@ export default class ChestPopMinigame {
                 return await interaction.reply({ content: 'You broke a key attemping to open it.', ephemeral: true });
     
             // Pick rewards from opening with key
-            const maxRewardAmount = STATE.CHANCE.natural({ min: 3, max: 7 });
+            const maxRewardAmount = STATE.CHANCE.natural({ min: 2, max: 5 });
             const rewardAmount = STATE.CHANCE.natural({ min: 1, max: maxRewardAmount });
             const drops = DropTable.getRandomWithQtyMany(rewardAmount);
 


### PR DESCRIPTION
Fixed drop table to now use proper weight rarity foor picking a random tier:
- Average table is the base value (most common) (100%)
- Rare table occurs twice as less as average (50%)
- Legendary table occurs 5 times as less as average (20%)

Chestpop now rewards a bit less items, also tiered with the droptable fix